### PR TITLE
CO-1048 map academic standings

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/students/mapper/AcademicStandingMapper.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/students/mapper/AcademicStandingMapper.groovy
@@ -10,7 +10,7 @@ import java.sql.SQLException
 public class AcademicStandingMapper implements ResultSetMapper<AcademicStatusObject> {
     public AcademicStatusObject map(int i, ResultSet rs, StatementContext sc) throws SQLException {
         new AcademicStatusObject(
-                academicStanding: rs.getString("academic_standing"),
+                academicStanding: rs.getString("academic_standing").replace('*', '').trim(),
                 academicProbation: rs.getString("academic_probation_ind") == "Y",
                 registrationBlocked: rs.getString("blocks_registration_ind") == "Y"
         )

--- a/src/main/groovy/edu/oregonstate/mist/students/mapper/AcademicStandingMapper.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/students/mapper/AcademicStandingMapper.groovy
@@ -1,6 +1,7 @@
 package edu.oregonstate.mist.students.mapper
 
 import edu.oregonstate.mist.students.core.AcademicStatusObject
+import org.apache.commons.lang3.text.WordUtils
 import org.skife.jdbi.v2.StatementContext
 import org.skife.jdbi.v2.tweak.ResultSetMapper
 
@@ -9,10 +10,11 @@ import java.sql.SQLException
 
 public class AcademicStandingMapper implements ResultSetMapper<AcademicStatusObject> {
     public AcademicStatusObject map(int i, ResultSet rs, StatementContext sc) throws SQLException {
+        def rawStanding = rs.getString("academic_standing")
         new AcademicStatusObject(
-                academicStanding: rs.getString("academic_standing").replace('*', '').trim(),
-                academicProbation: rs.getString("academic_probation_ind") == "Y",
-                registrationBlocked: rs.getString("blocks_registration_ind") == "Y"
+            academicStanding: WordUtils.capitalizeFully(rawStanding.replace('*', '').trim()),
+            academicProbation: rs.getString("academic_probation_ind") == "Y",
+            registrationBlocked: rs.getString("blocks_registration_ind") == "Y"
         )
     }
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -103,13 +103,13 @@ definitions:
                   - "Good Standing"
                   - "Academic Dismissal - Graduate"
                   - "Continued Deferred Suspension"
-                  - "**** HONOR ROLL ****"
+                  - "Honor Roll"
                   - "Academic Probation"
                   - "Special Deferred Suspension"
                   - "Academic Suspension"
                   - "Deferred Suspension"
                   - "Academic Warning"
-                  - "Reinstatement after Suspension"
+                  - "Reinstatement After Suspension"
               registrationBlocked:
                 type: boolean
                 example: false


### PR DESCRIPTION
Right now, I capitalize all words including the prepositions, for example: `Reinstatement after Suspension` will become `Reinstatement After Suspension`. I know in English we don't usually capitalize the prepositions, but I am not sure should we add a condition to ignore capitalizing `after`or not. If there are new standing descriptions with other prepositions like `of` in the future, should we also hardcode them as well? Another option is we can lowercase all words. @jaredkosanovic what do you think?