### PR TITLE
display weekly schedule as array

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/students/core/ClassSchedule.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/students/core/ClassSchedule.groovy
@@ -88,13 +88,7 @@ class MeetingTime {
     BigDecimal hoursPerWeek
     Integer creditHourSession
     String scheduleType
-    Boolean meetsSunday
-    Boolean meetsMonday
-    Boolean meetsTuesday
-    Boolean meetsWednesday
-    Boolean meetsThursday
-    Boolean meetsFriday
-    Boolean meetsSaturday
+    List<String> weeklySchedule
 
     static fromBackendMeetingTime(BackendMeetingTime backendMeetingTime) {
         backendMeetingTime.with {
@@ -110,14 +104,38 @@ class MeetingTime {
                     hoursPerWeek: hoursWeek,
                     creditHourSession: creditHourSession,
                     scheduleType: meetingScheduleType,
-                    meetsSunday: sunday,
-                    meetsMonday: monday,
-                    meetsTuesday: tuesday,
-                    meetsWednesday: wednesday,
-                    meetsThursday: thursday,
-                    meetsFriday: friday,
-                    meetsSaturday: saturday
+                    weeklySchedule: parseWeeklySchedule(backendMeetingTime)
             )
         }
+    }
+
+    private static List<String> parseWeeklySchedule(BackendMeetingTime backendMeetingTime) {
+        List<String> weeklySchedule = []
+
+        backendMeetingTime.with {
+            if (monday) {
+                weeklySchedule.add("M")
+            }
+            if (tuesday) {
+                weeklySchedule.add("T")
+            }
+            if (wednesday) {
+                weeklySchedule.add("W")
+            }
+            if (thursday) {
+                weeklySchedule.add("Th")
+            }
+            if (friday) {
+                weeklySchedule.add("F")
+            }
+            if (saturday) {
+                weeklySchedule.add("Sa")
+            }
+            if (sunday) {
+                weeklySchedule.add("Su")
+            }
+        }
+
+        weeklySchedule
     }
 }

--- a/src/test/groovy/edu/oregonstate/mist/students/TestHelperObjects.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/students/TestHelperObjects.groovy
@@ -125,13 +125,7 @@ class TestHelperObjects {
                     hoursPerWeek: 1.33,
                     creditHourSession: 4,
                     scheduleType: "A",
-                    meetsSunday: false,
-                    meetsMonday: true,
-                    meetsTuesday: true,
-                    meetsWednesday: true,
-                    meetsThursday: true,
-                    meetsFriday: true,
-                    meetsSaturday: true
+                    weeklySchedule: ['M', 'W', 'F']
             )]
     )]
 }

--- a/src/test/groovy/edu/oregonstate/mist/students/core/ClassScheduleTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/students/core/ClassScheduleTest.groovy
@@ -1,0 +1,49 @@
+package edu.oregonstate.mist.students.core
+
+import edu.oregonstate.mist.students.db.BackendMeetingTime
+import org.junit.Test
+
+import static org.junit.Assert.assertEquals
+
+class ClassScheduleTest {
+    @Test
+    void testWeeklyScheduleMapping() {
+        BackendMeetingTime backendMeetingTime = new BackendMeetingTime()
+
+        backendMeetingTime.with {
+            monday = wednesday = friday = true
+            tuesday = thursday = saturday = sunday = false
+        }
+        MeetingTime meetingTime = MeetingTime.fromBackendMeetingTime(backendMeetingTime)
+        assertEquals(meetingTime.weeklySchedule, ['M', 'W', 'F'])
+
+        backendMeetingTime.with {
+            // test that null days aren't included in the array, null should == false
+            monday = thursday = null
+            tuesday = saturday = sunday = true
+            wednesday = friday = false
+        }
+        meetingTime = MeetingTime.fromBackendMeetingTime(backendMeetingTime)
+        assertEquals(meetingTime.weeklySchedule, ['T', 'Sa', 'Su'])
+    }
+
+    @Test
+    void testWeeklyScheduleAllOrNone() {
+        BackendMeetingTime backendMeetingTime = new BackendMeetingTime()
+
+        backendMeetingTime.with {
+            monday = tuesday = wednesday = thursday = friday = saturday = sunday = true
+        }
+        MeetingTime meetingTime = MeetingTime.fromBackendMeetingTime(backendMeetingTime)
+        assertEquals(meetingTime.weeklySchedule, ['M', 'T', 'W', 'Th', 'F', 'Sa', 'Su'])
+
+        backendMeetingTime.with {
+            monday = tuesday = wednesday = thursday = friday = saturday = sunday = false
+        }
+        meetingTime = MeetingTime.fromBackendMeetingTime(backendMeetingTime)
+        assertEquals(meetingTime.weeklySchedule, [])
+
+        meetingTime = MeetingTime.fromBackendMeetingTime(new BackendMeetingTime())
+        assertEquals(meetingTime.weeklySchedule, [])
+    }
+}

--- a/src/test/groovy/edu/oregonstate/mist/students/db/StudentsDAOWrapperTest.groovy
+++ b/src/test/groovy/edu/oregonstate/mist/students/db/StudentsDAOWrapperTest.groovy
@@ -1,5 +1,6 @@
-package edu.oregonstate.mist.students
+package edu.oregonstate.mist.students.db
 
+import edu.oregonstate.mist.students.TestHelperObjects
 import edu.oregonstate.mist.students.core.AcademicStatus
 import edu.oregonstate.mist.students.core.AccountBalance
 import edu.oregonstate.mist.students.core.AccountTransactions

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -633,34 +633,24 @@ definitions:
                         type: string
                         example: "A"
                         enum: [B, C, D, E, F, G, H, I, J, K, A, L, M, N, O, P , Q, R, S, T, U, W, Y, Z, V, X, MID, FIL, HYB]
-                      meetsSunday:
-                        description: Whether this meeting time meets on Sunday.
-                        type: boolean
-                        example: false
-                      meetsMonday:
-                        description: Whether this meeting time meets on Monday.
-                        type: boolean
-                        example: true
-                      meetsTuesday:
-                        description: Whether this meeting time meets on Tuesday.
-                        type: boolean
-                        example: false
-                      meetsWednesday:
-                        description: Whether this meeting time meets on Wednesday.
-                        type: boolean
-                        example: true
-                      meetsThursday:
-                        description: Whether this meeting time meets on Thursday.
-                        type: boolean
-                        example: false
-                      meetsFriday:
-                        description: Whether this meeting time meets on Friday.
-                        type: boolean
-                        example: true
-                      meetsSaturday:
-                        description: Whether this meeting time meets on Saturday.
-                        type: boolean
-                        example: false
+                      weeklySchedule:
+                        description: |
+                          Array of day abbreviations to represent which days of the week this meeting time occurs on.
+                          If an abbreviation is present in the array, the meeting time meets on that day of the week.
+                          The meeting time does not meet on any days of the week which aren't in the array.
+                          Abbreviations and their corresponding day of the week:
+                          M: Monday
+                          T: Tuesday
+                          W: Wednesday
+                          Th: Thursday
+                          F: Friday
+                          Sa: Saturday
+                          Su: Sunday
+                        type: array
+                        example: ["M", "W", "F"]
+                        items:
+                          type: string
+                          enum:  [M, T, W, Th, F, Sa, Su]
             links:
               $ref: "#/definitions/NullSelfLink"
   HoldsResultObject:


### PR DESCRIPTION
Instead of having a separate field for each day of the week a course meets, display it as a single field with an array of day abbreviations